### PR TITLE
rename app to @frontmen/hyperapp-redux-devtools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,53 @@
-# @hyperapp/redux-devtools
+# @frontmen/hyperapp-redux-devtools
 
-[![Travis CI](https://travis-ci.org/FrontMen/hyperapp-redux-devtools.svg?branch=master)](https://travis-ci.org/hyperapp/redux-devtools)
-[![Codecov](https://img.shields.io/codecov/c/github/FrontMen/hyperapp-redux-devtools/master.svg)](https://codecov.io/gh/hyperapp/redux-devtools)
-[![npm](https://img.shields.io/npm/v/@frontmen/hyperapp-redux-devtools.svg)](https://www.npmjs.org/package/@hyperapp/redux-devtools)
+[![Travis CI](https://img.shields.io/travis/FrontMen/hyperapp-redux-devtools/master.svg)](https://travis-ci.org/FrontMen/hyperapp-redux-devtools)
+[![codecov](https://codecov.io/gh/FrontMen/hyperapp-redux-devtools/branch/master/graph/badge.svg)](https://codecov.io/gh/FrontMen/hyperapp-redux-devtools)
+[![npm](https://img.shields.io/npm/v/@frontmen/hyperapp-redux-devtools.svg)](https://www.npmjs.org/package/@frontmen/hyperapp-redux-devtools)
 [![Slack](https://hyperappjs.herokuapp.com/badge.svg)](https://hyperappjs.herokuapp.com "Join us")
 
 A [Hyperapp](https://github.com/hyperapp/hyperapp) higher-order `app` that logs state updates to redux devtools.
 
-[Try it Online](https://codepen.io/okwolf/pen/xLQmvW?editors=0010)
+[Try it Online](https://codepen.io/lassecapel/pen/QaMKXQ?editors=0010)
 
-![Screenshot](https://user-images.githubusercontent.com/3735164/34082934-657f864c-e31c-11e7-93d2-d70f190aa928.png)
+<!-- ![Screenshot](https://user-images.githubusercontent.com/3735164/34082934-657f864c-e31c-11e7-93d2-d70f190aa928.png) -->
 
 ## Installation
 
 ### Node.js
 
+
 Install with npm / Yarn.
 
 <pre>
-npm i <a href="https://www.npmjs.com/package/@hyperapp/redux-devtools">@hyperapp/redux-devtools</a>
+npm i <a href="https://www.npmjs.com/package/@frontmen/hyperapp-redux-devtools">@frontmen/hyperapp-redux-devtools</a>
 </pre>
 
 Then with a module bundler like [rollup](https://github.com/rollup/rollup) or [webpack](https://github.com/webpack/webpack) use as you would anything else.
 
 ```jsx
-import redux-devtools from "@hyperapp/redux-devtools"
+import withReduxDevtools from "@frontmen/hyperapp-redux-devtools"
+// Or as a named import: 
+import { withReduxDevtools } from "@frontmen/hyperapp-redux-devtools"
 ```
 
 ### Browser
 
-Download the minified library from the [CDN](https://unpkg.com/@hyperapp/redux-devtools).
+Download the minified library from the [CDN](https://unpkg.com/Frontmen/hyperapp-redux-devtools).
 
 ```html
-<script src="https://unpkg.com/@hyperapp/redux-devtools"></script>
+<script src="https://unpkg.com/Frontmen/hyperapp-redux-devtools"></script>
 ```
 
-You can find the library in `window.redux-devtools`.
+You can find the library in `window.withReduxDevtools`.
 
 ## Usage
 
 ```js
-import devtools from 'hyperapp-redux-devtools';
+import withReduxDevtools from 'hyperapp-redux-devtools';
 
-devtools(app)(state, actions, view, document.body)
+withReduxDevtools(app)(state, actions, view, document.body)
 ```
 
 ## License
 
-@hyperapp/redux-devtools is MIT licensed. See [LICENSE](LICENSE.md).
+@frontmen/hyperapp-redux-devtools is MIT licensed. See [LICENSE](LICENSE.md).

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hyperapp-redux-devtools",
+  "name": "@frontmen/hyperapp-redux-devtools",
   "version": "0.0.1",
   "description": "higher order app to connect state to redux-devtools",
   "main": "dist/index.js",


### PR DESCRIPTION
Make readme module specific, copied a lot from @hyperapp/logger to keep the style a little in sync